### PR TITLE
Fix symlinks

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+	symlinks = true

--- a/img/models/avatars/Peasant Nolant Brown.fbx
+++ b/img/models/avatars/Peasant Nolant Brown.fbx
@@ -1,1 +1,1 @@
-Kaydara FBX Binary  
+Peasant Nolant Blue.fbx

--- a/img/models/avatars/Peasant Nolant Green.fbx
+++ b/img/models/avatars/Peasant Nolant Green.fbx
@@ -1,1 +1,1 @@
-Kaydara FBX Binary  
+Peasant Nolant Blue.fbx

--- a/img/models/avatars/Peasant Nolant Yellow.fbx
+++ b/img/models/avatars/Peasant Nolant Yellow.fbx
@@ -1,1 +1,1 @@
-Kaydara FBX Binary  
+Peasant Nolant Blue.fbx


### PR DESCRIPTION
Somebody broke the symlinks by not having symlinks enabled in git.

@ronnypollak @JOKeRiino @Rakanishuu please make sure to enable symlinks in git (or we need to "triplicate" [does that word even exist?] the peasant nolant models)

run
``` console
git config --local --add include.path ../.gitconfig
```
for the repo when this PR is accepted.

On Windows, symlinks require admin perms or developer mode turned on (Settings --> Updates & security --> for developers --> Install apps from any source, including loose files [translated back from German windows, maybe different if really English windows is used, it's the first option])